### PR TITLE
MIDI Clock Info plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DESTDIR =
 all: plugins
 
 plugins:
+	$(MAKE) -C midi-clock-info.lv2
 	$(MAKE) -C midi-switchbox_1-2.lv2
 	$(MAKE) -C midi-switchbox_1-3.lv2
 	$(MAKE) -C midi-switchbox_2-1.lv2
@@ -14,6 +15,7 @@ plugins:
 	$(MAKE) -C peak-to-cc.lv2
 
 install:
+	$(MAKE) install PREFIX=$(PREFIX) -C midi-clock-info.lv2
 	$(MAKE) install PREFIX=$(PREFIX) -C midi-switchbox_1-2.lv2
 	$(MAKE) install PREFIX=$(PREFIX) -C midi-switchbox_1-3.lv2
 	$(MAKE) install PREFIX=$(PREFIX) -C midi-switchbox_2-1.lv2
@@ -23,6 +25,7 @@ install:
 	$(MAKE) install PREFIX=$(PREFIX) -C peak-to-cc.lv2
 
 clean:
+	$(MAKE) clean -C midi-clock-info.lv2
 	$(MAKE) clean -C midi-switchbox_1-2.lv2
 	$(MAKE) clean -C midi-switchbox_1-3.lv2
 	$(MAKE) clean -C midi-switchbox_2-1.lv2

--- a/midi-clock-info.lv2/Makefile
+++ b/midi-clock-info.lv2/Makefile
@@ -1,0 +1,21 @@
+include ../Makefile.mk
+
+NAME = midi-clock-info
+
+all: build
+build: $(NAME).so
+
+$(NAME).so: $(NAME).c.o
+	$(CXX) $^ $(LDFLAGS) -shared -Wl,--no-undefined -o $@
+
+$(NAME).c.o: $(NAME).c
+	$(CC) $< $(CFLAGS) -c -o $@
+
+clean:
+	rm -f *.o *.so
+
+install: build
+	install -d $(DESTDIR)$(PREFIX)/lib/lv2/$(NAME).lv2
+
+	install -m 644 *.so  $(DESTDIR)$(PREFIX)/lib/lv2/$(NAME).lv2/
+	install -m 644 *.ttl $(DESTDIR)$(PREFIX)/lib/lv2/$(NAME).lv2/

--- a/midi-clock-info.lv2/manifest.ttl
+++ b/midi-clock-info.lv2/manifest.ttl
@@ -1,0 +1,7 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://moddevices.com/plugins/mod-devel/midi-clock-info>
+    a lv2:Plugin ;
+    lv2:binary <midi-clock-info.so>  ;
+    rdfs:seeAlso <midi-clock-info.ttl> .

--- a/midi-clock-info.lv2/midi-clock-info.c
+++ b/midi-clock-info.lv2/midi-clock-info.c
@@ -189,18 +189,17 @@ static void run(LV2_Handle instance, uint32_t sample_count)
                     *self->port_ctrl_out_mtc_seconds = self->mtc.seconds;
                     *self->port_ctrl_out_mtc_minutes = self->mtc.minutes;
                     *self->port_ctrl_out_mtc_hours = self->mtc.hours;
-                    {
 #ifdef DEBUG_PLUGIN_LOG
-                        fprintf(stdout, "MIDI Clock Info: MTC -> %02i:%02i:%02i:%03i\n",
-                                self->mtc.hours, self->mtc.minutes, self->mtc.seconds, self->mtc.frame);
-                        fflush(stdout);
+                    fprintf(stdout, "MIDI Clock Info: MTC -> %02i:%02i:%02i:%03i\n",
+                            self->mtc.hours, self->mtc.minutes, self->mtc.seconds, self->mtc.frame);
+                    fflush(stdout);
 #endif
-                    }
                     break;
                 }
 
                 break;
             }
+
             case 0xF2: // MIDI Song Position Pointer
             {
                 const int value = msg[1] + 128 * msg[2];
@@ -211,9 +210,11 @@ static void run(LV2_Handle instance, uint32_t sample_count)
 #endif
                 break;
             }
+
             case 0xF8: // MIDI Clock "Pulse"
                 // TODO
                 break;
+
             case 0xFA: // MIDI Clock Start
                 *self->port_ctrl_out_play_status = kPlayStatusStart;
 #ifdef DEBUG_PLUGIN_LOG
@@ -221,6 +222,7 @@ static void run(LV2_Handle instance, uint32_t sample_count)
                 fflush(stdout);
 #endif
                 break;
+
             case 0xFB: // MIDI Clock Continue
                 *self->port_ctrl_out_play_status = kPlayStatusContinue;
 #ifdef DEBUG_PLUGIN_LOG
@@ -228,14 +230,13 @@ static void run(LV2_Handle instance, uint32_t sample_count)
                 fflush(stdout);
 #endif
                 break;
+
             case 0xFC: // MIDI Clock Stop
                 *self->port_ctrl_out_play_status = kPlayStatusStop;
 #ifdef DEBUG_PLUGIN_LOG
                 fprintf(stdout, "MIDI Clock Info: play status -> stop\n");
                 fflush(stdout);
 #endif
-                break;
-            default:
                 break;
             }
         }

--- a/midi-clock-info.lv2/midi-clock-info.c
+++ b/midi-clock-info.lv2/midi-clock-info.c
@@ -1,0 +1,247 @@
+/*
+ */
+
+#include <lv2/lv2plug.in/ns/lv2core/lv2.h>
+#include <lv2/lv2plug.in/ns/ext/atom/util.h>
+#include <lv2/lv2plug.in/ns/ext/midi/midi.h>
+#include <lv2/lv2plug.in/ns/ext/urid/urid.h>
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define DEBUG_PLUGIN_LOG
+
+typedef enum {
+    PORT_RAW_MIDI_IN = 0,
+    PORT_CTRL_OUT_PLAY_STATUS,
+    PORT_CTRL_OUT_MIDI_TIME_CLOCK,
+    PORT_CTRL_OUT_SONG_POSITION_POINTER,
+    // TODO raw BPM based on clock pulse
+    // TODO filtered BPM
+    // TODO BPM/clock-pulse drift
+} PortEnum;
+
+typedef struct {
+    int frame, frameLSB;
+    int seconds, secondsLSB;
+    int minutes, minutesLSB;
+    int hours, hoursLSB;
+} MTC;
+
+typedef struct {
+    // URIDs
+    LV2_URID urid_atomSequence;
+    LV2_URID urid_midiEvent;
+
+    // data flow ports
+    const LV2_Atom_Sequence* port_events_in;
+
+    // control ports
+    float* port_ctrl_out_play_status;
+    float* port_ctrl_out_midi_time_clock;
+    float* port_ctrl_out_song_pos_ptr;
+
+    // internal state
+    bool needs_reset;
+    MTC mtc;
+} Data;
+
+// values of `PORT_CTRL_OUT_PLAY_STATUS` port, as defined in the TTL
+static const float kPlayStatusUndefined = 0.0f;
+static const float kPlayStatusStart = 1.0f;
+static const float kPlayStatusStop = 2.0f;
+static const float kPlayStatusContinue = 3.0f;
+
+static LV2_Handle instantiate(const LV2_Descriptor*     descriptor,
+                              double                    rate,
+                              const char*               path,
+                              const LV2_Feature* const* features)
+{
+    Data* self = (Data*)calloc(1, sizeof(Data));
+
+    // Get host features
+    const LV2_URID_Map* map = NULL;
+
+    for (int i = 0; features[i]; ++i) {
+        if (!strcmp(features[i]->URI, LV2_URID__map)) {
+            map = (const LV2_URID_Map*)features[i]->data;
+            break;
+        }
+    }
+    if (!map) {
+        free(self);
+        return NULL;
+    }
+
+    // Map URIs
+    self->urid_atomSequence = map->map(map->handle, LV2_ATOM__Sequence);
+    self->urid_midiEvent    = map->map(map->handle, LV2_MIDI__MidiEvent);
+
+    return self;
+}
+
+static void connect_port(LV2_Handle instance, uint32_t port, void* data)
+{
+    Data* const self = (Data*)instance;
+
+    switch (port)
+    {
+    case PORT_RAW_MIDI_IN:
+            self->port_events_in = (const LV2_Atom_Sequence*)data;
+            break;
+    case PORT_CTRL_OUT_PLAY_STATUS:
+            self->port_ctrl_out_play_status = (float*)data;
+            break;
+    case PORT_CTRL_OUT_MIDI_TIME_CLOCK:
+            self->port_ctrl_out_midi_time_clock = (float*)data;
+            break;
+    case PORT_CTRL_OUT_SONG_POSITION_POINTER:
+            self->port_ctrl_out_song_pos_ptr = (float*)data;
+            break;
+    }
+}
+
+static void activate(LV2_Handle instance)
+{
+    Data* const self = (Data*)instance;
+
+    self->needs_reset = true;
+    memset(&self->mtc, 0, sizeof(self->mtc));
+}
+
+static void run(LV2_Handle instance, uint32_t sample_count)
+{
+    Data* const self = (Data*)instance;
+
+    if (self->needs_reset)
+    {
+        *self->port_ctrl_out_play_status = kPlayStatusUndefined;
+        *self->port_ctrl_out_midi_time_clock = 0.0f;
+        *self->port_ctrl_out_song_pos_ptr = 0.0f;
+        self->needs_reset = false;
+#ifdef DEBUG_PLUGIN_LOG
+        fprintf(stdout, "MIDI Clock Info: reset\n");
+        fflush(stdout);
+#endif
+    }
+
+    // Read incoming events
+    LV2_ATOM_SEQUENCE_FOREACH(self->port_events_in, ev)
+    {
+        if (ev->body.type == self->urid_midiEvent)
+        {
+            const uint8_t* const msg = (const uint8_t*)(ev + 1);
+
+            switch (msg[0])
+            {
+            case 0xF1: // MIDI Time Code (Quarter Frame)
+            {
+                const int type  = (msg[2] >> 4) & 0xf;
+                const int value =  msg[2] & 0xf;
+#ifdef DEBUG_PLUGIN_LOG
+                fprintf(stdout, "MIDI Clock Info: type %i, value %i\n", type, value);
+                fflush(stdout);
+#endif
+
+                switch (type)
+                {
+                case 0:
+                    self->mtc.frameLSB = value;
+                    break;
+                case 1:
+                    self->mtc.frame = self->mtc.frameLSB + (value * 16);
+                    break;
+                case 2:
+                    self->mtc.secondsLSB = value;
+                    break;
+                case 3:
+                    self->mtc.seconds = self->mtc.secondsLSB + (value * 16);
+                    break;
+                case 4:
+                    self->mtc.minutesLSB = value;
+                    break;
+                case 5:
+                    self->mtc.minutes = self->mtc.minutesLSB + (value * 16);
+                    break;
+                case 6:
+                    self->mtc.hoursLSB = value & 0x1f;
+                    break;
+                case 7:
+                    self->mtc.hours = self->mtc.hoursLSB + ((value * 16) & 0x1f);
+//                     if (self->mtc.frame == 28)
+                    {
+                        const int rvalue = self->mtc.seconds + (60 * self->mtc.minutes) + (3600 * self->mtc.hours);
+                        *self->port_ctrl_out_midi_time_clock = rvalue;
+#ifdef DEBUG_PLUGIN_LOG
+                        fprintf(stdout, "MIDI Clock Info: MTC -> %i\n", rvalue);
+                        fflush(stdout);
+#endif
+                    }
+                    break;
+                }
+
+                break;
+            }
+            case 0xF2: // MIDI Song Position Pointer
+            {
+                const int value = msg[1] + 128 * msg[2];
+                *self->port_ctrl_out_song_pos_ptr = value;
+#ifdef DEBUG_PLUGIN_LOG
+                fprintf(stdout, "MIDI Clock Info: song pos ptr -> %i\n", value);
+                fflush(stdout);
+#endif
+                break;
+            }
+            case 0xF8: // MIDI Clock "Pulse"
+                // TODO
+                break;
+            case 0xFA: // MIDI Clock Start
+                *self->port_ctrl_out_play_status = kPlayStatusStart;
+#ifdef DEBUG_PLUGIN_LOG
+                fprintf(stdout, "MIDI Clock Info: play status -> start\n");
+                fflush(stdout);
+#endif
+                break;
+            case 0xFB: // MIDI Clock Continue
+                *self->port_ctrl_out_play_status = kPlayStatusContinue;
+#ifdef DEBUG_PLUGIN_LOG
+                fprintf(stdout, "MIDI Clock Info: play status -> continue\n");
+                fflush(stdout);
+#endif
+                break;
+            case 0xFC: // MIDI Clock Stop
+                *self->port_ctrl_out_play_status = kPlayStatusStop;
+#ifdef DEBUG_PLUGIN_LOG
+                fprintf(stdout, "MIDI Clock Info: play status -> stop\n");
+                fflush(stdout);
+#endif
+                break;
+            default:
+                break;
+            }
+        }
+    }
+}
+
+static void cleanup(LV2_Handle instance)
+{
+    free((Data*)instance);
+}
+
+static const LV2_Descriptor descriptor = {
+    .URI = "http://moddevices.com/plugins/mod-devel/midi-clock-info",
+    .instantiate = instantiate,
+    .connect_port = connect_port,
+    .activate = activate,
+    .run = run,
+    .deactivate = NULL,
+    .cleanup = cleanup,
+    .extension_data = NULL
+};
+
+LV2_SYMBOL_EXPORT
+const LV2_Descriptor* lv2_descriptor(uint32_t index)
+{
+    return (index == 0) ? &descriptor : NULL;
+}

--- a/midi-clock-info.lv2/midi-clock-info.ttl
+++ b/midi-clock-info.lv2/midi-clock-info.ttl
@@ -54,16 +54,46 @@
                 a lv2:InputPort ,
                         lv2:ControlPort ;
                 lv2:index 2 ;
-                lv2:symbol "mtc" ;
-                lv2:name "MIDI Time Clock" ;
+                lv2:symbol "mtc_frame" ;
+                lv2:name "MTC " ;
                 lv2:default 0 ;
                 lv2:minimum 0 ;
-                lv2:maximum 16383 ;
+                lv2:maximum 255 ;
                 lv2:portProperty lv2:integer ;
         ] , [
                 a lv2:InputPort ,
                         lv2:ControlPort ;
                 lv2:index 3 ;
+                lv2:symbol "mtc_s" ;
+                lv2:name "MTC Seconds" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 59 ;
+                lv2:portProperty lv2:integer ;
+        ] , [
+                a lv2:InputPort ,
+                        lv2:ControlPort ;
+                lv2:index 4 ;
+                lv2:symbol "mtc_m" ;
+                lv2:name "MTC Minutes" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 59 ;
+                lv2:portProperty lv2:integer ;
+        ] , [
+                a lv2:InputPort ,
+                        lv2:ControlPort ;
+                lv2:index 5 ;
+                lv2:symbol "mtc_h" ;
+                lv2:name "MTC Hours" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 23 ;
+                lv2:portProperty lv2:integer ;
+        ] , [
+                a lv2:InputPort ,
+                        lv2:ControlPort ;
+                lv2:index 6 ;
                 lv2:symbol "spp" ;
                 lv2:name "Song Position Pointer" ;
                 lv2:default 0 ;

--- a/midi-clock-info.lv2/midi-clock-info.ttl
+++ b/midi-clock-info.lv2/midi-clock-info.ttl
@@ -1,0 +1,88 @@
+@prefix atom: <http://lv2plug.in/ns/ext/atom#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix midi: <http://lv2plug.in/ns/ext/midi#> .
+@prefix mod:  <http://moddevices.com/ns/mod#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://moddevices.com/plugins/mod-devel/midi-clock-info>
+        a mod:MIDIPlugin ,
+            lv2:UtilityPlugin ,
+            lv2:Plugin ;
+        doap:name "MIDI Clock Info" ;
+        doap:license "GPLv2+" ;
+        rdfs:comment "MIDI Clock Information as a plugin." ;
+        lv2:minorVersion 0 ;
+        lv2:microVersion 0 ;
+        lv2:optionalFeature lv2:hardRTCapable ;
+        lv2:port [
+                a lv2:InputPort ,
+                        atom:AtomPort ;
+                atom:bufferType atom:Sequence ;
+                atom:supports midi:MidiEvent ;
+                lv2:index 0 ;
+                lv2:symbol "in" ;
+                lv2:name "In" ;
+                lv2:portProperty mod:rawMIDIClockAccess ;
+        ] , [
+                a lv2:OutputPort ,
+                        lv2:ControlPort ;
+                lv2:index 1 ;
+                lv2:symbol "play_status" ;
+                lv2:name "Play Status" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 3 ;
+                lv2:portProperty lv2:integer ,
+                                 lv2:enumeration ;
+                lv2:scalePoint [
+                        rdfs:label "Undefined" ;
+                        rdf:value 0 ;
+                ] , [
+                        rdfs:label "Start" ;
+                        rdf:value 1 ;
+                ] , [
+                        rdfs:label "Stop" ;
+                        rdf:value 2 ;
+                ] , [
+                        rdfs:label "Continue" ;
+                        rdf:value 3 ;
+                ] ;
+        ] , [
+                a lv2:InputPort ,
+                        lv2:ControlPort ;
+                lv2:index 2 ;
+                lv2:symbol "mtc" ;
+                lv2:name "MIDI Time Clock" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 16383 ;
+                lv2:portProperty lv2:integer ;
+        ] , [
+                a lv2:InputPort ,
+                        lv2:ControlPort ;
+                lv2:index 3 ;
+                lv2:symbol "spp" ;
+                lv2:name "Song Position Pointer" ;
+                lv2:default 0 ;
+                lv2:minimum 0 ;
+                lv2:maximum 16383 ;
+                lv2:portProperty lv2:integer ;
+        ] ;
+
+        doap:developer [
+            foaf:name "Filipe Coelho" ;
+            foaf:homepage <http://falktx.com> ;
+            foaf:mbox <falktx@moddevices.com> ;
+        ] ;
+
+        doap:maintainer [
+            foaf:name "MOD Team" ;
+            foaf:homepage <http://moddevices.com> ;
+            foaf:mbox <mailto:devel@moddevices.com> ;
+        ] ;
+
+        mod:brand "MOD" ;
+        mod:label "MIDI Clock Info" .


### PR DESCRIPTION
Work-in-progress, but already works and has a few useful values out.
Has the new custom `mod:rawMIDIClockAccess` on its MIDI input port, which will make it hidden from the user and connect to all hw MIDI sources behind the scenes.

MIDI Clock "pulse" (for BPM) is not implemented yet.
